### PR TITLE
CSS modules options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ module.exports = {
 };
 ```
 
+You can also pass options directly to
+[postcss-modules](https://github.com/css-modules/postcss-modules):
+
+```javascript
+module.exports = {
+  // ...
+  plugins: {
+    css: {
+      modules: {
+        generateScopedName: '[name]__[local]___[hash:base64:5]'
+      }
+    }
+  }
+};
+```
+
 Then, author your styles like you normally would:
 
 ```css

--- a/index.js
+++ b/index.js
@@ -3,14 +3,15 @@
 const postcss = require('postcss');
 const postcssModules = require('postcss-modules');
 
-const cssModulify = (path, data, map) => {
+const cssModulify = (path, data, map, options) => {
   let json = {};
   const getJSON = (_, _json) => json = _json;
 
-  return postcss([postcssModules({getJSON})]).process(data, {from: path, map}).then(x => {
-    const exports = 'module.exports = ' + JSON.stringify(json) + ';';
-    return { data: x.css, map: x.map, exports };
-  });
+  return postcss([postcssModules(Object.assign({}, {getJSON}, options))])
+    .process(data, {from: path, map}).then(x => {
+      const exports = 'module.exports = ' + JSON.stringify(json) + ';';
+      return { data: x.css, map: x.map, exports };
+    });
 };
 
 class CSSCompiler {
@@ -21,7 +22,8 @@ class CSSCompiler {
   }
   compile(params) {
     if (this.modules) {
-      return cssModulify(params.path, params.data, params.map);
+      const moduleOptions = this.modules === true ? {} : this.modules;
+      return cssModulify(params.path, params.data, params.map, moduleOptions);
     } else {
       return Promise.resolve(params);
     }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
-    "postcss": "~5.0.19",
-    "postcss-modules": "~0.4.0"
+    "postcss": "~5.1.2",
+    "postcss-modules": "~0.5.0"
   },
   "devDependencies": {
     "mocha": "1.11.0",


### PR DESCRIPTION
Same thing as done in sass-brunch.

Just want to make a note here until postcss-brunch is fixed and I can test how it interacts.

Most postcss plugins are fine to run on the concatenated style-sheet, however postcss-import would need to be run before postcss-modules as it could bring in classes that would then need to be transformed and exported. There might be other plugins which would need to run before as well if they also effect the class list (precss-postcss-brunch anyone? :unamused:).

This is not an issue for Sass since `@import` and everything is processed into CSS first and modulifyed. See for example https://github.com/react-toolbox/react-toolbox/pull/666 which is switching away from Sass imports.