### PR TITLE
Added an ignore option for CSSModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,23 @@ var style = require('./title.css');
 <h1 className={style.title}>Yo</h1>
 ```
 
-Note: enabling `cssModules` does so for every stylesheet in your project, so it's all-or-nothing. Even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
+Note: enabling `cssModules` does so for every stylesheet in your project, even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
+
+You must use the ignore option to specifically opt out of files or directories where you don't want to use cssModules.
+
+The ignore option takes an array of matches. [Anymatch](https://github.com/es128/anymatch) is used to handle the matching. See the [anymatch documentation](https://github.com/es128/anymatch) for more information.
+```javascript
+module.exports = {
+  // ...
+  plugins: {
+    css: {
+      modules: {
+        ignore: [/file\.css/, /some\/path\/to\/ignore/]
+      }
+    }
+  }
+};
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const postcss = require('postcss');
 const postcssModules = require('postcss-modules');
+const anymatch = require('anymatch');
 
 const cssModulify = (path, data, map, options) => {
   let json = {};
@@ -19,9 +20,16 @@ class CSSCompiler {
     if (cfg == null) cfg = {};
     this.config = cfg.plugins && cfg.plugins.css || {};
     this.modules = !!(this.config.modules || this.config.cssModules);
+
+    if (this.modules && this.config.modules.ignore) {
+      this.isIgnored = anymatch(this.config.modules.ignore);
+      delete this.config.modules.ignore;
+    } else {
+      this.isIgnored = anymatch([]);
+    }
   }
   compile(params) {
-    if (this.modules) {
+    if (this.modules && !this.isIgnored(params.path)) {
       const moduleOptions = this.modules === true ? {} : this.modules;
       return cssModulify(params.path, params.data, params.map, moduleOptions);
     } else {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
+    "anymatch": "^1.3.0",
     "postcss": "~5.1.2",
     "postcss-modules": "~0.5.0"
   },

--- a/test.js
+++ b/test.js
@@ -4,23 +4,46 @@ var Plugin = require('./');
 describe('Plugin', function() {
   var plugin;
 
-  beforeEach(function() {
-    plugin = new Plugin({});
-  });
-
   it('should be an object', function() {
+    plugin = new Plugin({});
     expect(plugin).to.be.ok;
   });
 
   it('should has #compile method', function() {
+    plugin = new Plugin({});
     expect(plugin.compile).to.be.an.instanceof(Function);
   });
 
-  it('should compile and produce valid result', function(done) {
-    var content = '#id {color: #6b0;}';
-    var expected = '#id {color: #6b0;}';
+  it('should compile with modules', function(done) {
+    var content = '.class {color: #6b0;}';
+    var expected = '._class_mcgck_1 {color: #6b0;}';
+    newPlugin = new Plugin({
+      plugins: {
+        css: {
+          modules: true
+        }
+      }
+    })
 
-    plugin.compile({data: content, path: 'file.css'}).then(result => {
+    newPlugin.compile({data: content, path: 'file.css'}).then(result => {
+      var data = result.data;
+      expect(data).to.equal(expected);
+      done();
+    }, error => expect(error).not.to.be.ok);
+  });
+
+  it('should compile skip files passed to ignore', function(done) {
+    var content = '.class {color: #6b0;}';
+    var expected = '.class {color: #6b0;}';
+    newPlugin = new Plugin({
+      plugins: {
+        css: {
+          modules: {ignore: [/file\.css/]}
+        }
+      }
+    })
+
+    newPlugin.compile({data: content, path: 'file.css'}).then(result => {
       var data = result.data;
       expect(data).to.equal(expected);
       done();


### PR DESCRIPTION
It seems pretty common that users may have global stylesheets or css libraries
that they want to use while still taking advantage of CSSModules in their
javascript components. I needed this myself and figure it will be useful to
others too.
